### PR TITLE
Use JSON serializer with keys as strings, not atoms

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,7 +4,7 @@ config :commanded,
   event_store_adapter: Commanded.EventStore.Adapters.EventStore
 
 config :eventstore, EventStore.Storage,
-  serializer: Commanded.Serialization.JsonSerializer,
+  serializer: Seelies.JsonSerializer,
   username: "seelies",
   password: "b?t>J0yD{8<1",
   database: "seelies_event_store_dev",

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,7 +4,7 @@ config :commanded,
   event_store_adapter: Commanded.EventStore.Adapters.EventStore
 
 config :eventstore, EventStore.Storage,
-  serializer: Commanded.Serialization.JsonSerializer,
+  serializer: Seelies.JsonSerializer,
   username: "seelies",
   password: "b?t>J0yD{8<1",
   database: "seelies_event_store_test",

--- a/lib/seelies/json_serializer.ex
+++ b/lib/seelies/json_serializer.ex
@@ -1,0 +1,38 @@
+defmodule Seelies.JsonSerializer do
+  alias Commanded.EventStore.TypeProvider
+  alias Commanded.Serialization.JsonDecoder
+
+  @doc """
+  Serialize given term to JSON binary data.
+  """
+  def serialize(term) do
+    Jason.encode!(term)
+  end
+
+  @doc """
+  Deserialize given JSON binary data to the expected type.
+  """
+  def deserialize(binary, config \\ []) do
+    {type, opts} =
+      case Keyword.get(config, :type) do
+        nil -> {nil, %{}}
+        type -> {TypeProvider.to_struct(type), %{keys: :strings}}
+      end
+
+    binary
+    |> Jason.decode!(opts)
+    |> keys_to_atoms()
+    |> to_struct(type)
+    |> JsonDecoder.decode()
+  end
+
+  # Convert top level map keys to atoms.
+  defp keys_to_atoms(map) when is_map(map) do
+    for {key, value} <- map, into: %{} do
+      {String.to_atom(key), value}
+    end
+  end
+
+  defp to_struct(data, nil), do: data
+  defp to_struct(data, struct), do: struct(struct, data)
+end

--- a/test/support/aggregate_case.ex
+++ b/test/support/aggregate_case.ex
@@ -25,9 +25,10 @@ defmodule Conduit.AggregateCase do
         deserialized_events =
           Enum.map(actual_events, fn event ->
             event_type = Commanded.EventStore.TypeProvider.to_string(event)
+
             event
-              |> Commanded.Serialization.JsonSerializer.serialize()
-              |> Commanded.Serialization.JsonSerializer.deserialize(type: event_type)
+            |> Seelies.JsonSerializer.serialize()
+            |> Seelies.JsonSerializer.deserialize(type: event_type)
           end)
 
         IO.inspect(deserialized_events)


### PR DESCRIPTION
Configure Jason to deserialize keys to strings (`keys: :strings`) and then convert the top-level map keys to atoms to allow conversion to the type struct.